### PR TITLE
Modify script because awk util is not exist in 0629 binary

### DIFF
--- a/script/container_network.sh
+++ b/script/container_network.sh
@@ -4,40 +4,34 @@ set -e
 
 HOSTS_FILE="/etc/hosts"
 HOSTNAME_FILE="/etc/hostname"
-SUBNETMASK="255.255.0.0"
+SUBNETMASK="255.255.255.0"
 
 if [ -s $HOSTNAME_FILE ] && [ -s $HOSTS_FILE ]; then
-	HOSTNAME=`cat $HOSTNAME_FILE`
+	HOSTNAME=`cat $HOSTNAME_FILE`	
+	HOST=$(cat $HOSTS_FILE | grep $HOSTNAME | cut -f2)
+	IP=$(cat $HOSTS_FILE | grep $HOSTNAME | cut -f1)
+	CONTAINER_IP=$IP
+	echo 'host :' $HOSTNAME
+	echo 'host2 :' $HOST
+	echo 'IP :' $IP	
 
-	while read line; do
-		IP=$(echo $line | awk '{print $1}')
-		HOST=$(echo $line | awk '{print $2}')
-		if [ $HOSTNAME = $HOST ]; then
-			CONTAINER_IP=$IP
-#			echo $CONTAINER_IP
-			break
-		fi
-	done < $HOSTS_FILE
 fi
 
-ORG_IP=$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-if [ ! $ORG_IP ]; then
-    ORG_IP="0.0.0.0"
-fi
-echo 'ip : '$ORG_IP
 
-if [ $CONTAINER_IP != $ORG_IP ]; then
-	var=$(echo $CONTAINER_IP | awk -F"." '{print $1,$2,$3,$4}')
-	set -- $var 
-	GATEWAY=$1'.'
-	GATEWAY=$GATEWAY$2'.'
-	GATEWAY=$GATEWAY$3'.'
-	GATEWAY=$GATEWAY'1' 
-	echo $GATEWAY
-fi
+FIRST=$(echo $CONTAINER_IP | cut -d . -f1)
+SECOND=$(echo $CONTAINER_IP | cut -d . -f2)
+THIRD=$(echo $CONTAINER_IP | cut -d . -f3)
+FORTH=$(echo $CONTAINER_IP | cut -d . -f4)
+
+GATEWAY=$FIRST'.'
+GATEWAY=$GATEWAY$SECOND'.'
+GATEWAY=$GATEWAY$THIRD'.'
+GATEWAY=$GATEWAY'1' 
+echo $GATEWAY
+
 
 if [ $CONTAINER_IP ] && [ $GATEWAY ]; then
-	SERVICE=`connmanctl services | grep ethernet | awk '{print $3}'`
+	SERVICE=`connmanctl services | grep ethernet | rev | cut -d ' ' -f1 | rev`
 	connmanctl config $SERVICE --ipv4 manual $CONTAINER_IP $SUBNETMASK $GATEWAY
 	echo 'staic IP setting by connman' $CONTAINER_IP
 fi


### PR DESCRIPTION
In order to parse string of ip address, awk was used but removed in new binary
cut util is using for parsing ip address.

Signed-off-by: Lee Namsu <nshero.lee@samsung.com>